### PR TITLE
Update AddDefenderExceptions.ps1

### DIFF
--- a/AddDefenderExceptions.ps1
+++ b/AddDefenderExceptions.ps1
@@ -33,24 +33,41 @@ if ($WindowsPrincipal.IsInRole($AdminRole)) {
 	exit
 }
 
-write-host "Important: Run this script from the directory root with which Rookie will be run to exclude"
-Start-Sleep -s 5
+write-host "Run this script from the directory root with which Rookie will be run"
+start-sleep -s 5
 
+$paths = @(
+    "$PSScriptRoot",  # Replaces 'C:\RSL' with the script's root directory
+    "$PSScriptRoot\Rookie",
+    "$PSScriptRoot\Rookie\rclone",
+    "$PSScriptRoot\Rookie\Sideloader Launcher.exe",
+    "$PSScriptRoot\Rookie\AndroidSideloader*.exe",
+    "$PSScriptRoot\Rookie\rclone\rclone.exe"
+)
+
+foreach ($path in $paths) {
     try {
-        Add-MpPreference -ExclusionPath $PSScriptRoot -ErrorAction Stop
-        Write-Host "Successfully added exclusion for: $PSScriptRoot " -ForegroundColor Green
+        Add-MpPreference -ExclusionPath $Path -ErrorAction Stop
+        Write-Host "Successfully added exclusion for: $path" -ForegroundColor Green
     }
     catch {
-        Write-Host "Failed to add exclusion for: $PSScriptRoot " -ForegroundColor Red
+        Write-Host "Failed to add exclusion for: $path " -ForegroundColor Red
         Write-Host "Error: $_" -ForegroundColor Red
 	Start-Sleep -s 5
 	Pause
     }
-
+}
 
 # Verify the exclusions
 Write-Host "`nCurrent exclusions:" -ForegroundColor Cyan
-Get-MpPreference | Select-Object -ExpandProperty ExclusionPath | Where-Object { $_ -like $PSScriptRoot }
-
+$defenderPreferences = Get-MpPreference
+$paths | ForEach-Object {
+    if ($defenderPreferences.ExclusionPath -contains $_) {
+        Write-Host "$_ is already excluded from Defender."
+    } else {
+        Write-Host "$_ is NOT excluded from Defender."
+    }
+}
+pause
 
 Start-Sleep -s 5

--- a/AddDefenderExceptions.ps1
+++ b/AddDefenderExceptions.ps1
@@ -38,11 +38,10 @@ start-sleep -s 5
 
 $paths = @(
     "$PSScriptRoot",  # Replaces 'C:\RSL' with the script's root directory
-    "$PSScriptRoot\Rookie",
-    "$PSScriptRoot\Rookie\rclone",
-    "$PSScriptRoot\Rookie\Sideloader Launcher.exe",
-    "$PSScriptRoot\Rookie\AndroidSideloader*.exe",
-    "$PSScriptRoot\Rookie\rclone\rclone.exe"
+    "$PSScriptRoot\rclone",
+    "$PSScriptRoot\Sideloader Launcher.exe",
+    "$PSScriptRoot\AndroidSideloader*.exe",
+    "$PSScriptRoot\rclone\rclone.exe"
 )
 
 foreach ($path in $paths) {
@@ -68,6 +67,6 @@ $paths | ForEach-Object {
         Write-Host "$_ is NOT excluded from Defender."
     }
 }
-pause
+Pause
 
 Start-Sleep -s 5

--- a/AddDefenderExceptions.ps1
+++ b/AddDefenderExceptions.ps1
@@ -1,31 +1,56 @@
 # Run this script as Administrator
 # powershell -ExecutionPolicy Bypass -File "C:\RSL\Rookie\AddDefenderExceptions.ps1"
 
-if (-NOT ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) {
-    Write-Warning "Please run this script as Administrator!"
-    exit
+
+################################################################
+## Auto Elevate to Admin if not running as admin
+################################################################
+
+# Get the ID and security principal of the current user account
+$WindowsID = [System.Security.Principal.WindowsIdentity]::GetCurrent()
+$WindowsPrincipal = New-Object System.Security.Principal.WindowsPrincipal ($WindowsID)
+
+# Get the security principal for the Administrator role
+$AdminRole = [System.Security.Principal.WindowsBuiltInRole]::Administrator
+
+# Check to see if we are currently running "as Administrator"
+if ($WindowsPrincipal.IsInRole($AdminRole)) {
+	# We are running "as Administrator" - so change the title and background color to indicate this
+	$Host.UI.RawUI.WindowTitle = $myInvocation.MyCommand.Definition + " (Elevated)"
+	$Host.UI.RawUI.BackgroundColor = "DarkBlue"
+	Clear-Host
+} else {
+	# We are not running "as Administrator" - so relaunch as administrator
+	# Create a new process object that starts PowerShell
+	$NewProcess = New-Object System.Diagnostics.ProcessStartInfo "PowerShell";
+	# Specify the current script path and name as a parameter
+	$NewProcess.Arguments = $myInvocation.MyCommand.Definition;
+	# Indicate that the process should be elevated
+	$NewProcess.Verb = "runas";
+	# Start the new process
+	[System.Diagnostics.Process]::Start($NewProcess);
+	# Exit from the current unelevated process
+	exit
 }
 
-$paths = @(
-    "C:\RSL",
-    "C:\RSL\Rookie",
-    "C:\RSL\Rookie\rclone",
-    "C:\RSL\Rookie\Sideloader Launcher.exe",
-    "C:\RSL\Rookie\AndroidSideloader*.exe",
-    "C:\RSL\Rookie\rclone\rclone.exe"
-)
+write-host "Important: Run this script from the directory root with which Rookie will be run to exclude"
+Start-Sleep -s 5
 
-foreach ($path in $paths) {
     try {
-        Add-MpPreference -ExclusionPath $path -ErrorAction Stop
-        Write-Host "Successfully added exclusion for: $path" -ForegroundColor Green
+        Add-MpPreference -ExclusionPath $PSScriptRoot -ErrorAction Stop
+        Write-Host "Successfully added exclusion for: $PSScriptRoot " -ForegroundColor Green
     }
     catch {
-        Write-Host "Failed to add exclusion for: $path" -ForegroundColor Red
+        Write-Host "Failed to add exclusion for: $PSScriptRoot " -ForegroundColor Red
         Write-Host "Error: $_" -ForegroundColor Red
+	Start-Sleep -s 5
+	Pause
     }
-}
+
 
 # Verify the exclusions
 Write-Host "`nCurrent exclusions:" -ForegroundColor Cyan
-Get-MpPreference | Select-Object -ExpandProperty ExclusionPath | Where-Object { $_ -like "C:\RSL*" }
+Get-MpPreference | Select-Object -ExpandProperty ExclusionPath | Where-Object { $_ -like $PSScriptRoot }
+
+
+Start-Sleep -s 5


### PR DESCRIPTION
Added an auto elevate to admin section instead of admin check.

Replaced array of paths with psscriptroot for 2 reasons; 
1. This lets users exclude whatever folder they want regardless of install path
2. Defender excludes all subdirectories and files recursively making all those entries redundant https://support.microsoft.com/en-us/windows/add-an-exclusion-to-windows-security-811816c0-4dfd-af4a-47e4-c301afe13b26

Finally,
I added some sleeps and pauses for users to review messages and results/errors