### PR TITLE
Changed C:\RSL\platform-tools path to platform-tools in working dir

### DIFF
--- a/ADB.cs
+++ b/ADB.cs
@@ -11,7 +11,7 @@ namespace AndroidSideloader
     {
         private static readonly SettingsManager settings = SettingsManager.Instance;
         private static readonly Process adb = new Process();
-        public static string adbFolderPath = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools");
+        public static string adbFolderPath = Path.Combine(Environment.CurrentDirectory, "platform-tools");
         public static string adbFilePath = Path.Combine(adbFolderPath, "adb.exe");
         public static string DeviceID = "";
         public static string package = "";

--- a/MainForm.cs
+++ b/MainForm.cs
@@ -65,12 +65,16 @@ namespace AndroidSideloader
         public static PublicConfig PublicConfigFile;
         public static string PublicMirrorExtraArgs = " --tpslimit 1.0 --tpslimit-burst 3";
         public static Splash SplashScreen;
+        public static string storedIpPath;
+        public static string aaptPath;
         private bool manualIP;
         private System.Windows.Forms.Timer _debounceTimer;
         private CancellationTokenSource _cts;
         private List<ListViewItem> _allItems;
         public MainForm()
         {
+            storedIpPath = Path.Combine(Environment.CurrentDirectory, "platform-tools", "StoredIP.txt");
+            aaptPath = Path.Combine(Environment.CurrentDirectory, "platform-tools", "aapt.exe");
             InitializeComponent();
             Logger.Initialize();
             InitializeTimeReferences();
@@ -306,7 +310,7 @@ namespace AndroidSideloader
             }
 
             _ = Logger.Log("Attempting to Initalize ADB Server");
-            if (File.Exists(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "adb.exe")))
+            if (File.Exists(Path.Combine(Environment.CurrentDirectory, "platform-tools", "adb.exe")))
             {
                 _ = ADB.RunAdbCommandToString("kill-server");
                 _ = ADB.RunAdbCommandToString("start-server");
@@ -424,8 +428,8 @@ namespace AndroidSideloader
             {
                 if (!string.IsNullOrEmpty(settings.IPAddress))
                 {
-                    string path = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "adb.exe");
-                    ProcessOutput wakeywakey = ADB.RunCommandToString($"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\adb.exe shell input keyevent KEYCODE_WAKEUP", path);
+                    string path = Path.Combine(Environment.CurrentDirectory, "platform-tools", "adb.exe");
+                    ProcessOutput wakeywakey = ADB.RunCommandToString($"\"{path}\" shell input keyevent KEYCODE_WAKEUP", path);
                     if (wakeywakey.Output.Contains("more than one"))
                     {
                         settings.Wired = true;
@@ -438,9 +442,9 @@ namespace AndroidSideloader
                     }
                 }
 
-                if (File.Exists(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt")) && !settings.Wired)
+                if (File.Exists(storedIpPath) && !settings.Wired)
                 {
-                    string IPcmndfromtxt = File.ReadAllText(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt"));
+                    string IPcmndfromtxt = File.ReadAllText(storedIpPath);
                     settings.IPAddress = IPcmndfromtxt;
                     settings.Save();
                     ProcessOutput IPoutput = ADB.RunAdbCommandToString(IPcmndfromtxt);
@@ -449,7 +453,7 @@ namespace AndroidSideloader
                         _ = FlexibleMessageBox.Show(Program.form, "Attempt to connect to saved IP has failed. This is usually due to rebooting the device or not having a STATIC IP set in your router.\nYou must enable Wireless ADB again!");
                         settings.IPAddress = "";
                         settings.Save();
-                        try { File.Delete(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt")); }
+                        try { File.Delete(storedIpPath); }
                         catch (Exception ex) { Logger.Log($"Unable to delete StoredIP.txt due to {ex.Message}", LogLevel.ERROR); }
                     }
                     else
@@ -458,7 +462,7 @@ namespace AndroidSideloader
                         _ = ADB.RunAdbCommandToString("shell settings put global wifi_wakeup_enabled 1");
                     }
                 }
-                else if (!File.Exists(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt")))
+                else if (!File.Exists(storedIpPath))
                 {
                     settings.IPAddress = "";
                     settings.Save();
@@ -1395,7 +1399,8 @@ namespace AndroidSideloader
                                 string pathname = Path.GetDirectoryName(file2);
                                 string filename = file2.Replace($"{pathname}\\", String.Empty);
 
-                                string cmd = $"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\aapt.exe\" dump badging \"{file2}\" | findstr -i \"package: name\"";
+                                string cmd = $"\"{aaptPath}\" dump badging \"{file2}\" | findstr -i \"package: name\"";
+
                                 _ = Logger.Log($"Running adb command-{cmd}");
                                 string cmdout = ADB.RunCommandToString(cmd, file2).Output;
                                 cmdout = Utilities.StringUtilities.RemoveEverythingBeforeFirst(cmdout, "=");
@@ -1546,7 +1551,7 @@ namespace AndroidSideloader
                         {
                             string pathname = Path.GetDirectoryName(data);
                             string dataname = data.Replace($"{pathname}\\", "");
-                            string cmd = $"\"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\aapt.exe\" dump badging \"{data}\" | findstr -i \"package: name\"";
+                            string cmd = $"\"{aaptPath}\" dump badging \"{data}\" | findstr -i \"package: name\"";
                             _ = Logger.Log($"Running adb command-{cmd}");
                             string cmdout = ADB.RunCommandToString(cmd, data).Output;
                             cmdout = Utilities.StringUtilities.RemoveEverythingBeforeFirst(cmdout, "=");
@@ -2003,6 +2008,7 @@ namespace AndroidSideloader
                            }
                        }*/
                     //This is for games that are not blacklisted and we dont have on rookie
+                    string baseApkPath = Path.Combine(Environment.CurrentDirectory, "platform-tools", "base.apk");
                     if (blacklistItems.Count > 100 && rookieList.Count > 100 && !noAppCheck)
                     {
                         foreach (string newGamesToUpload in newGamesList)
@@ -2030,23 +2036,22 @@ namespace AndroidSideloader
                                     Logger.Log($"ADB command 'pm path' executed. Path: {apppath}", LogLevel.INFO);
                                     apppath = Utilities.StringUtilities.RemoveEverythingBeforeFirst(apppath, "/");
                                     apppath = Utilities.StringUtilities.RemoveEverythingAfterFirst(apppath, "\r\n");
-                                    if (File.Exists(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "base.apk")))
+                                    if (File.Exists(baseApkPath))
                                     {
-                                        File.Delete(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "base.apk"));
+                                        File.Delete(baseApkPath);
                                         Logger.Log("Old base.apk file deleted.", LogLevel.INFO);
                                     }
 
                                     Logger.Log($"Pulling APK from path: {apppath}", LogLevel.INFO);
                                     _ = ADB.RunAdbCommandToString($"pull \"{apppath}\"");
-                                    string cmd = $"\"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\aapt.exe\" dump badging \"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\base.apk\" | findstr -i \"application-label\"";
-                                    string workingpath = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "aapt.exe");
+                                    string cmd = $"\"{aaptPath}\" dump badging \"{baseApkPath}\" | findstr -i \"application-label\"";
                                     Logger.Log($"Running AAPT command: {cmd}", LogLevel.INFO);
-                                    string ReleaseName = ADB.RunCommandToString(cmd, workingpath).Output;
+                                    string ReleaseName = ADB.RunCommandToString(cmd, aaptPath).Output;
                                     Logger.Log($"AAPT command output: {ReleaseName}", LogLevel.INFO);
                                     ReleaseName = Utilities.StringUtilities.RemoveEverythingBeforeFirst(ReleaseName, "'");
                                     ReleaseName = Utilities.StringUtilities.RemoveEverythingAfterFirst(ReleaseName, "\r\n");
                                     ReleaseName = ReleaseName.Replace("'", "");
-                                    File.Delete(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "base.apk"));
+                                    File.Delete(baseApkPath);
                                     Logger.Log("Base.apk deleted after extracting release name.", LogLevel.INFO);
                                     if (ReleaseName.Contains("Microsoft Windows"))
                                     {
@@ -2445,7 +2450,7 @@ namespace AndroidSideloader
                     settings.Save();
                     try
                     {
-                        File.WriteAllText(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt"), IPcmnd);
+                        File.WriteAllText(storedIpPath, IPcmnd);
                     }
                     catch (Exception ex) { Logger.Log($"Unable to write to StoredIP.txt due to {ex.Message}", LogLevel.ERROR); }
                     ADB.wirelessadbON = true;
@@ -3395,9 +3400,9 @@ Please visit our Telegram (https://t.me/VRPirates) or Discord (https://discord.g
                 _ = Program.form.GetDeviceID();
                 Program.form.changeTitlebarToDevice();
                 _ = FlexibleMessageBox.Show(Program.form, "Relaunch Rookie to complete the process and switch back to USB adb.");
-                if (File.Exists(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt")))
+                if (File.Exists(storedIpPath))
                 {
-                    File.Delete(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt"));
+                    File.Delete(storedIpPath);
                 }
             }
         }
@@ -4086,7 +4091,7 @@ Please visit our Telegram (https://t.me/VRPirates) or Discord (https://discord.g
                         Program.form.showAvailableSpace();
                         settings.IPAddress = IPcmnd;
                         settings.Save();
-                        try { File.WriteAllText(Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL", "platform-tools", "StoredIP.txt"), IPcmnd); }
+                        try { File.WriteAllText(storedIpPath, IPcmnd); }
                         catch (Exception ex) { Logger.Log($"Unable to write to StoredIP.txt due to {ex.Message}", LogLevel.ERROR); }
                         ADB.wirelessadbON = true;
                         _ = ADB.RunAdbCommandToString("shell settings put global wifi_wakeup_available 1");

--- a/Sideloader/GetDependencies.cs
+++ b/Sideloader/GetDependencies.cs
@@ -108,19 +108,22 @@ namespace AndroidSideloader
                 _ = FlexibleMessageBox.Show($"You are unable to access raw.githubusercontent.com with the Exception:\n{ex.Message}\n\nSome files may be missing (Offline/Cleanup Script, Launcher)");
             }
 
+            string adbPath = Path.Combine(Environment.CurrentDirectory, "platform-tools", "adb.exe");
+            string platformToolsDir = Path.Combine(Environment.CurrentDirectory, "platform-tools");
+
             try
             {
-                if (!File.Exists($"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools\\adb.exe")) //if adb is not updated, download and auto extract
+                if (!File.Exists(adbPath)) //if adb is not updated, download and auto extract
                 {
-                    if (!Directory.Exists($"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools"))
+                    if (!Directory.Exists(platformToolsDir))
                     {
-                        _ = Directory.CreateDirectory($"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools");
+                        _ = Directory.CreateDirectory(platformToolsDir);
                     }
 
                     currentAccessedWebsite = "github";
-                    _ = Logger.Log($"Missing adb within {Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools. Attempting to download from {currentAccessedWebsite}");
+                    _ = Logger.Log($"Missing adb within {platformToolsDir}. Attempting to download from {currentAccessedWebsite}");
                     client.DownloadFile("https://github.com/VRPirates/rookie/raw/master/dependencies.7z", "dependencies.7z");
-                    Utilities.Zip.ExtractFile(Path.Combine(Environment.CurrentDirectory, "dependencies.7z"), $"{Path.GetPathRoot(Environment.SystemDirectory)}RSL\\platform-tools");
+                    Utilities.Zip.ExtractFile(Path.Combine(Environment.CurrentDirectory, "dependencies.7z"), platformToolsDir);
                     File.Delete("dependencies.7z");
                     _ = Logger.Log($"adb download successful");
                 }


### PR DESCRIPTION
Partially solves https://github.com/VRPirates/rookie/issues/83.

I don't think it is safe to use system-wide adb when Rookie writes older version here (and writes other stuff there too).
I tested what I could, dependency download is working fine, launching adb as well, but currently I cannot reach FTP server as my packets get dropped, so I can't test it completely.