### PR TITLE
Fix #199

### DIFF
--- a/MainForm.cs
+++ b/MainForm.cs
@@ -3710,6 +3710,22 @@ Please visit our Telegram (https://t.me/VRPirates) or Discord (https://discord.g
 
         private async Task CreateEnvironment()
         {
+            webView21.CoreWebView2InitializationCompleted += (sender, e) => {
+                webView21.CoreWebView2.ContainsFullScreenElementChanged += (obj, args) =>
+                {
+                    this.FullScreen = webView21.CoreWebView2.ContainsFullScreenElement;
+                };
+
+                webView21.CoreWebView2.NavigationCompleted += (obj, args) =>
+                {
+                    if (!args.IsSuccess)
+                    {
+                        CoreWebView2 wv2 = (CoreWebView2)obj;
+                        Logger.Log($"Failed to navigate to '{wv2.Source}': {args.WebErrorStatus}");
+                    }
+                };
+            };
+
             string appDataLocation = Path.Combine(Path.GetPathRoot(Environment.SystemDirectory), "RSL");
             var webView2Environment = await CoreWebView2Environment.CreateAsync(userDataFolder: appDataLocation);
             await webView21.EnsureCoreWebView2Async(webView2Environment);
@@ -3721,19 +3737,6 @@ Please visit our Telegram (https://t.me/VRPirates) or Discord (https://discord.g
             {
                 // Load the video URL in the web browser control
                 webView21.CoreWebView2.Navigate(videoUrl);
-                webView21.CoreWebView2.ContainsFullScreenElementChanged += (obj, args) =>
-                {
-                    this.FullScreen = webView21.CoreWebView2.ContainsFullScreenElement;
-                };
-
-                webView21.CoreWebView2.NavigationCompleted += (obj, args) => 
-                {
-                    if (!args.IsSuccess)
-                    {
-                        CoreWebView2 wv2 = (CoreWebView2)obj;
-                        Logger.Log($"Failed to navigate to '{wv2.Source}': {args.WebErrorStatus}");
-                    }
-                };
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
# Summary
This PR provides a fix for #199.

# Details
- Trailer video downloading now uses HttpClient rather than the obsolete WebClient, also prevents the UI thread from locking up.

# Note
I tested the WV2 fix by scrolling through the list. Memory climbed ~10MB, and CPU stayed below 8%. It would probably be best to test this on a "potato" to ensure the fix still won't deadlock the UI thread. Ask Aemee.